### PR TITLE
Upgrade dependencies

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,9 +4,9 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/clojurescript "0.0-3196"]
-                 [figwheel "0.2.7-SNAPSHOT"]
+  :dependencies [[org.clojure/clojure "1.7.0-RC1"]
+                 [org.clojure/clojurescript "0.0-3308"]
+                 [figwheel "0.3.5"]
                  [org.clojure/core.async "0.1.346.0-17112a-alpha"]
                  [org.omcljs/om "0.8.8"]
                  [sablono "0.3.4"]]

--- a/project.clj
+++ b/project.clj
@@ -46,6 +46,7 @@
                          :optimizations :advanced
                          :pretty-print false}}]}
 
+  :aliases {"test" ["cljsbuild" "test"]}
   :figwheel {
              :http-server-root "public" ;; default and assumes "resources" 
              :server-port 4449 ;; default


### PR DESCRIPTION
aliasing the test makes also "lein ancient upgrade" run the tests automatically..

It still seems to work after the upgrade (even if I had to change to clojure 1.7 as well)
