### PR TITLE
Add `:recompile-dependents` to the `"test"` build

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -38,7 +38,8 @@
                          :asset-path "js/test/out"
                          :source-map true
                          ;; :source-map-timestamp true
-                         :cache-analysis true }}
+                         :cache-analysis true
+                         :recompile-dependents true}}
              {:id "min"
               :source-paths ["src"]
               :compiler {:output-to "resources/public/js/compiled/crashverse.js"


### PR DESCRIPTION
Fixes issue where new tests were not being picked up.
